### PR TITLE
Prepare for 1.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posix-space"
-version = "0.1.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-posix-space = "0.1.0"
+posix-space = "1.0.0"
 ```
 
 Then classify bytes like:
@@ -38,10 +38,19 @@ assert!(posix_space::is_space(b' '));
 assert!(posix_space::is_space(b'\t'));
 assert!(posix_space::is_space(b'\r'));
 
-
 assert!(!posix_space::is_space(b'\0'));
 assert!(!posix_space::is_space(b'C'));
 assert!(!posix_space::is_space(b'&'));
+```
+
+This crate's behavior differs from [`u8::is_ascii_whitespace`] in the Rust
+standard library in that \<vertical-tab\>, `\x0B`, is considered a **space**.
+
+[`u8::is_ascii_whitespace`]:
+  https://doc.rust-lang.org/stable/std/primitive.u8.html#method.is_ascii_whitespace
+
+```rust
+assert!(posix_space::is_space(b'\x0B'));
 ```
 
 ## Crate features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! > In the POSIX locale, exactly \<space\>, \<form-feed\>, \<newline\>, \<carriage-return\>,
 //! > \<tab\>, and \<vertical-tab\> shall be included.
 
-#![doc(html_root_url = "https://docs.rs/posix-space/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/posix-space/1.0.0")]
 #![no_std]
 
 // Ensure code blocks in README.md compile


### PR DESCRIPTION
Release 1.0.0 of posix-space.

[`posix-space` is available on crates.io](https://crates.io/crates/posix-space/1.0.0).

`posix-space` is a small crate that determines whether a byte is classified as a space in the POSIX locale per [POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/mindex.html).