### PR TITLE
Ignore man page links in markdown link check config

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://twitter.com/artichokeruby"
+    },
+    {
+      "pattern": "https://linux.die.net/man/3/isspace"
     }
   ],
   "replacementPatterns": [],


### PR DESCRIPTION
These pass locally but have been failing in CI for a while. Maybe the `linux.die.net` host is blocking GitHub Actions runners?

Ignoring this to eliminate the alert fatigue, which prevented me from catching these breakages for a month:

- https://github.com/artichoke/docker-artichoke-nightly/pull/187
- https://github.com/artichoke/playground/pull/1105